### PR TITLE
Make sure the TF discussion links in the README resolve correctly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ routes: {
 },
 ```
 
-* A [discussion of this issue](thethemefoundry.com/blog/backbone-js-routers-collections/)
+* A [discussion of this issue](https://thethemefoundry.com/blog/backbone-js-routers-collections/)
 
 ### Plugin support
 
@@ -75,7 +75,7 @@ wp_footer();
 ob_end_clean();
 ```
 
-* A [full discussion of this issue](thethemefoundry.com/blog/backbone-js-collections-plugin-compatibility/)
+* A [full discussion of this issue](https://thethemefoundry.com/blog/backbone-js-collections-plugin-compatibility/)
 
 ## A Backbone.js WordPress Theme Bill of Rights
 


### PR DESCRIPTION
Hey Zack,

I _finally_ got around to watching your talk on WPSessions and noticed that the links to the two important discussions you mentioned were broken in the readme because they don't contain a protocol. Currently if you click a link to either of those discussions from the readme on Github you'll end up going to [this](https://github.com/tollmanz/backbone-wordpress-theme/blob/master/thethemefoundry.com/blog/backbone-js-routers-collections) or [this](https://github.com/tollmanz/backbone-wordpress-theme/blob/master/thethemefoundry.com/blog/backbone-js-collections-plugin-compatibility) so this PR will fix that.

Also, massive props for your "Backbone.js WordPress Theme Bill of Rights" as well. I've been working on a few Backbone things internally but after hearing your bill of rights I've had to rethink some of my decisions which is awesome! :cake:
